### PR TITLE
Update package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,10 +10,10 @@
     "clean": "massa-sc-scripts clean"
   },
   "dependencies": {
-    "assemblyscript": "^0.19.20",
+    "assemblyscript": "^0.19.23",
     "json-as": "^0.2.6",
     "massa-sc-scripts": "4.0.3",
-    "massa-sc-std": "3.1.2",
-    "visitor-as": "^0.6.0"
+    "massa-sc-std": "3.2.2",
+    "visitor-as": "^0.8.0"
   }
 }


### PR DESCRIPTION
1) "visitor-as": "^0.6.0" conflicts with assemblyscript 0.19+ when we run npm install. We should update it to 0.8.0
2) update assemblyscript to 0.19.23
3) update massa-sc-std to 3.2.2